### PR TITLE
Plugin for Spark Connect ML - new plugin interface

### DIFF
--- a/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/MLBackendPlugin.java
+++ b/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/MLBackendPlugin.java
@@ -19,6 +19,11 @@ package org.apache.spark.sql.connect.plugin;
 
 import java.util.Optional;
 
+/**
+ * Behavior trait for supporting ML backend for the Spark Connect ML.
+ */
 public interface MLBackendPlugin {
-    Optional<String> replaceEstimator(String name);
+    // Replace the Spark ML estimator with backend implementations.
+    // Return Optional.empty() if not replacing
+    Optional<String> transform(String mlName);
 }

--- a/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/MLBackendPlugin.java
+++ b/sql/connect/server/src/main/java/org/apache/spark/sql/connect/plugin/MLBackendPlugin.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.plugin;
+
+import java.util.Optional;
+
+public interface MLBackendPlugin {
+    Optional<String> replaceEstimator(String name);
+}

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -214,6 +214,18 @@ object Connect {
       .toSequence
       .createWithDefault(Nil)
 
+  val CONNECT_ML_BACKEND_CLASSES =
+    buildStaticConf("spark.connect.ml.backend.classes")
+      .doc("""
+             |Comma separated list of classes that implement the trait
+             |org.apache.spark.sql.connect.plugin.MLBackendPlugin to replace the
+             |Estimators in spark.ml with third-party implementation.
+             |""".stripMargin)
+      .version("4.0.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   val CONNECT_JVM_STACK_TRACE_MAX_SIZE =
     buildStaticConf("spark.connect.jvmStacktrace.maxSize")
       .doc("""

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -215,7 +215,7 @@ object Connect {
       .createWithDefault(Nil)
 
   val CONNECT_ML_BACKEND_CLASSES =
-    buildStaticConf("spark.connect.ml.backend.classes")
+    buildConf("spark.connect.ml.backend.classes")
       .doc("""
              |Comma separated list of classes that implement the trait
              |org.apache.spark.sql.connect.plugin.MLBackendPlugin to replace the

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -117,7 +117,7 @@ private[connect] object MLHandler extends Logging {
         assert(estimatorProto.getType == proto.MlOperator.OperatorType.ESTIMATOR)
 
         val dataset = MLUtils.parseRelationProto(fitCmd.getDataset, sessionHolder)
-        val estimator = MLUtils.getEstimator(estimatorProto, Some(fitCmd.getParams))
+        val estimator = MLUtils.getEstimator(sessionHolder, estimatorProto, Some(fitCmd.getParams))
         val model = estimator.fit(dataset).asInstanceOf[Model[_]]
         val id = mlCache.register(model)
         proto.MlCommandResult
@@ -176,7 +176,8 @@ private[connect] object MLHandler extends Logging {
           case proto.MlCommand.Write.TypeCase.OPERATOR =>
             val writer = mlCommand.getWrite
             if (writer.getOperator.getType == proto.MlOperator.OperatorType.ESTIMATOR) {
-              val estimator = MLUtils.getEstimator(writer.getOperator, Some(writer.getParams))
+              val estimator = MLUtils.getEstimator(sessionHolder, writer.getOperator,
+                Some(writer.getParams))
               estimator match {
                 case m: MLWritable => MLUtils.write(m, mlCommand.getWrite)
                 case other => throw MlUnsupportedException(s"Estimator $other is not writable")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -17,9 +17,10 @@
 
 package org.apache.spark.sql.connect.ml
 
-import java.util.ServiceLoader
+import java.util.{Optional, ServiceLoader}
 
 import scala.collection.immutable.HashSet
+import scala.collection.mutable
 import scala.jdk.CollectionConverters._
 
 import org.apache.commons.lang3.reflect.MethodUtils.invokeMethod
@@ -32,8 +33,10 @@ import org.apache.spark.ml.util.MLWritable
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.sql.connect.common.LiteralValueProtoConverter
 import org.apache.spark.sql.connect.planner.SparkConnectPlanner
+import org.apache.spark.sql.connect.plugin.SparkConnectPluginRegistry
 import org.apache.spark.sql.connect.service.SessionHolder
 import org.apache.spark.util.{SparkClassUtils, Utils}
+
 
 private[ml] object MLUtils {
 
@@ -45,16 +48,26 @@ private[ml] object MLUtils {
    * @return
    *   a Map with name and class
    */
-  private def loadOperators(mlCls: Class[_]): Map[String, Class[_]] = {
+  private def loadOperators(mlCls: Class[_]): mutable.HashMap[String, Class[_]] = {
     val loader = Utils.getContextOrSparkClassLoader
     val serviceLoader = ServiceLoader.load(mlCls, loader)
     val providers = serviceLoader.asScala.toList
-    providers.map(est => est.getClass.getName -> est.getClass).toMap
+    mutable.HashMap.from(providers.map(est => est.getClass.getName -> est.getClass).toMap)
   }
 
   private lazy val estimators = loadOperators(classOf[Estimator[_]])
 
   private lazy val transformers = loadOperators(classOf[Transformer])
+
+  // visible for testing
+  private[ml] def addEstimator(name: String, mlCls: Class[_]): Unit = {
+    estimators.put(name, mlCls)
+  }
+  private[ml] def removeEstimator(name: String): Unit = {
+    if (estimators.contains(name)) {
+      estimators.remove(name)
+    }
+  }
 
   def deserializeVector(vector: proto.Vector): Vector = {
     if (vector.hasDense) {
@@ -212,7 +225,7 @@ private[ml] object MLUtils {
   private def getInstance[T](
       name: String,
       uid: String,
-      instanceMap: Map[String, Class[_]],
+      instanceMap: mutable.HashMap[String, Class[_]],
       params: Option[proto.MlParams]): T = {
     if (instanceMap.isEmpty || !instanceMap.contains(name)) {
       throw MlUnsupportedException(s"Unsupported ML operator, found $name")
@@ -239,7 +252,12 @@ private[ml] object MLUtils {
    *   the estimator
    */
   def getEstimator(operator: proto.MlOperator, params: Option[proto.MlParams]): Estimator[_] = {
-    val name = operator.getName
+    val name = SparkConnectPluginRegistry.mlBackendRegistry
+      .view
+      .map(p => p.replaceEstimator(operator.getName))
+      .find(_.isPresent)
+      .getOrElse(Optional.of(operator.getName))
+      .get()
     val uid = operator.getUid
     getInstance[Estimator[_]](name, uid, estimators, params)
   }

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistry.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/plugin/SparkConnectPluginRegistry.scala
@@ -21,6 +21,7 @@ import java.lang.reflect.InvocationTargetException
 
 import org.apache.spark.{SparkEnv, SparkException}
 import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.util.Utils
 
 /**
@@ -45,21 +46,15 @@ object SparkConnectPluginRegistry {
     // expression[DummyExpressionPlugin](classOf[DummyExpressionPlugin])
   )
 
-  private lazy val mlBackendChain: Seq[mlBackendBuilder] = Seq(
-
-  )
-
   private var initialized = false
   private var relationRegistryCache: Seq[RelationPlugin] = Seq.empty
   private var expressionRegistryCache: Seq[ExpressionPlugin] = Seq.empty
   private var commandRegistryCache: Seq[CommandPlugin] = Seq.empty
-  private lazy val mlBackendRegistryCache: Seq[MLBackendPlugin] = loadMlBackendPlugins()
 
   // Type used to identify the closure responsible to instantiate a ServerInterceptor.
   type relationPluginBuilder = () => RelationPlugin
   type expressionPluginBuilder = () => ExpressionPlugin
   type commandPluginBuilder = () => CommandPlugin
-  type mlBackendBuilder = () => MLBackendPlugin
 
   def relationRegistry: Seq[RelationPlugin] = withInitialize {
     relationRegistryCache
@@ -70,7 +65,7 @@ object SparkConnectPluginRegistry {
   def commandRegistry: Seq[CommandPlugin] = withInitialize {
     commandRegistryCache
   }
-  def mlBackendRegistry: Seq[MLBackendPlugin] = mlBackendRegistryCache
+  def mlBackendRegistry(conf: SQLConf): Seq[MLBackendPlugin] = loadMlBackendPlugins(conf)
 
   private def withInitialize[T](f: => Seq[T]): Seq[T] = {
     synchronized {
@@ -114,9 +109,9 @@ object SparkConnectPluginRegistry {
       SparkEnv.get.conf.get(Connect.CONNECT_EXTENSIONS_COMMAND_CLASSES))
   }
 
-  private[connect] def loadMlBackendPlugins(): Seq[MLBackendPlugin] = {
-    mlBackendChain.map(x => x()) ++ createConfiguredPlugins(
-      SparkEnv.get.conf.get(Connect.CONNECT_ML_BACKEND_CLASSES))
+  private[connect] def loadMlBackendPlugins(sqlConf: SQLConf): Seq[MLBackendPlugin] = {
+    createConfiguredPlugins(
+      sqlConf.getConf(Connect.CONNECT_ML_BACKEND_CLASSES))
   }
 
   /**

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
@@ -39,11 +39,11 @@ import org.apache.spark.sql.types.{FloatType, Metadata, StructField, StructType}
 
 class MyMlBackend extends MLBackendPlugin {
 
-  override def replaceEstimator(name: String): Optional[String] = {
-    if (name == "org.apache.spark.ml.classification.LogisticRegression") {
-      Optional.of("org.apache.spark.sql.connect.ml.MyLogisticRegression")
-    } else {
-      Optional.empty()
+  override def transform(mlName: String): Optional[String] = {
+    mlName match {
+      case "org.apache.spark.ml.classification.LogisticRegression" =>
+        Optional.of("org.apache.spark.sql.connect.ml.MyLogisticRegression")
+      case _ => Optional.empty()
     }
   }
 }

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.ml
+
+import java.util.Optional
+
+import org.apache.spark.{SparkEnv, SparkFunSuite}
+import org.apache.spark.connect.proto
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.linalg.{Vectors, VectorUDT}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.shared.HasMaxIter
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.connect.planner.SparkConnectPlanTest
+import org.apache.spark.sql.connect.plugin.MLBackendPlugin
+import org.apache.spark.sql.types.{FloatType, Metadata, StructField, StructType}
+
+
+class MyMlBackend extends MLBackendPlugin {
+
+  override def replaceEstimator(name: String): Optional[String] = {
+    if (name == "org.apache.spark.ml.classification.LogisticRegression") {
+      Optional.of("org.apache.spark.sql.connect.ml.MyLogisticRegression")
+    } else {
+      Optional.empty()
+    }
+  }
+}
+
+class MyLogisticRegressionModel(override val uid: String,
+                                val intercept: Float,
+                                val coefficients: Float)
+  extends Model[MyLogisticRegressionModel] with HasMaxIter {
+
+  override def copy(extra: ParamMap): MyLogisticRegressionModel =
+    defaultCopy(extra).asInstanceOf[MyLogisticRegressionModel]
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    dataset.toDF()
+  }
+
+  override def transformSchema(schema: StructType): StructType = schema
+}
+
+class MyLogisticRegression(override val uid: String) extends Estimator[MyLogisticRegressionModel]
+  with HasMaxIter {
+  setDefault(maxIter, 100)
+  def this() = this(Identifiable.randomUID("MyLogisticRegression"))
+
+  override def fit(dataset: Dataset[_]): MyLogisticRegressionModel = {
+    new MyLogisticRegressionModel(uid, 3.5f, 4.6f)
+  }
+
+  override def copy(extra: ParamMap): MyLogisticRegression = {
+    defaultCopy(extra).asInstanceOf[MyLogisticRegression]
+  }
+
+  override def transformSchema(schema: StructType): StructType = schema
+}
+
+class MLBackendSuite extends SparkFunSuite with SparkConnectPlanTest {
+
+  def createLocalRelationProto: proto.Relation = {
+    val udt = new VectorUDT()
+    val rows = Seq(
+      InternalRow(1.0f, udt.serialize(Vectors.dense(Array(1.0, 2.0)))),
+      InternalRow(1.0f, udt.serialize(Vectors.dense(Array(2.0, -1.0)))),
+      InternalRow(0.0f, udt.serialize(Vectors.dense(Array(-3.0, -2.0)))),
+      InternalRow(0.0f, udt.serialize(Vectors.dense(Array(-1.0, -2.0)))))
+
+    val schema = StructType(
+      Seq(
+        StructField("label", FloatType),
+        StructField("features", new VectorUDT(), false, Metadata.empty)))
+
+    val inputRows = rows.map { row =>
+      val proj = UnsafeProjection.create(schema)
+      proj(row).copy()
+    }
+    createLocalRelationProto(DataTypeUtils.toAttributes(schema), inputRows, "UTC", Some(schema))
+  }
+
+  def withSparkConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val conf = SparkEnv.get.conf
+    pairs.foreach { kv => conf.set(kv._1, kv._2) }
+    try f
+    finally {
+      pairs.foreach { kv => conf.remove(kv._1) }
+    }
+  }
+
+  test("MlBackendSuite") {
+    withSparkConf(
+      Connect.CONNECT_ML_BACKEND_CLASSES.key ->
+        "org.apache.spark.sql.connect.ml.MyMlBackend") {
+      val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+      val myEstClass = classOf[MyLogisticRegression]
+      try {
+        MLUtils.addEstimator(myEstClass.getName, myEstClass)
+
+        val fitCommand = proto.MlCommand
+          .newBuilder()
+          .setFit(
+            proto.MlCommand.Fit
+              .newBuilder()
+              .setDataset(createLocalRelationProto)
+              .setEstimator(
+                proto.MlOperator
+                  .newBuilder()
+                  .setName("org.apache.spark.ml.classification.LogisticRegression")
+                  .setUid("LogisticRegression")
+                  .setType(proto.MlOperator.OperatorType.ESTIMATOR))
+              .setParams(
+                proto.MlParams
+                  .newBuilder()
+                  .putParams(
+                    "maxIter",
+                    proto.Param
+                      .newBuilder()
+                      .setLiteral(proto.Expression.Literal
+                        .newBuilder()
+                        .setInteger(2))
+                      .build())))
+          .build()
+        val fitResult = MLHandler.handleMlCommand(sessionHolder, fitCommand)
+        val modelId = fitResult.getOperatorInfo.getObjRef.getId
+        assert(sessionHolder.mlCache.get(modelId).isInstanceOf[MyLogisticRegressionModel])
+        val model = sessionHolder.mlCache.get(modelId).asInstanceOf[MyLogisticRegressionModel]
+        assert(model.intercept == 3.5f)
+        assert(model.coefficients == 4.6f)
+      } finally {
+        MLUtils.removeEstimator(myEstClass.getName)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Users can specify the ML backends by

`spark.connect.ml.backend.classes="org.apache.spark.sql.connect.ml.MyMlBackend"`

While the MyMlBackend extends MLBackendPlugin and implements replaceEstimator where does the estimator replacement.

``` scala
class MyMlBackend extends MLBackendPlugin {

  override def replaceEstimator(name: String): Optional[String] = {
    if (name == "org.apache.spark.ml.classification.LogisticRegression") {
      Optional.of("org.apache.spark.sql.connect.ml.MyLogisticRegression")
    } else {
      Optional.empty()
    }
  }
}
```