### PR TITLE
plugin for connect ml - a new spark configuration does the estimator replacement.

### DIFF
--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -215,7 +215,7 @@ object Connect {
       .createWithDefault(Nil)
 
   val CONNECT_EXTENSIONS_ML_OVERRIDES =
-    buildStaticConf("spark.connect.extensions.ml.overrides")
+    buildConf("spark.connect.extensions.ml.overrides")
       .doc("""
              |Comma separated list of strings that specifies how to replace
              |the estimators using the third-party implementations.

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/config/Connect.scala
@@ -214,6 +214,20 @@ object Connect {
       .toSequence
       .createWithDefault(Nil)
 
+  val CONNECT_EXTENSIONS_ML_OVERRIDES =
+    buildStaticConf("spark.connect.extensions.ml.overrides")
+      .doc("""
+             |Comma separated list of strings that specifies how to replace
+             |the estimators using the third-party implementations.
+             |For example, spark.connect.extensions.ml.overrides=
+             |"org.apache.spark.ml.classification.LogisticRegression=
+             |com.example.MyLogisticRegression"
+             |""".stripMargin)
+      .version("4.0.0")
+      .stringConf
+      .toSequence
+      .createWithDefault(Nil)
+
   val CONNECT_JVM_STACK_TRACE_MAX_SIZE =
     buildStaticConf("spark.connect.jvmStacktrace.maxSize")
       .doc("""

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLHandler.scala
@@ -117,7 +117,7 @@ private[connect] object MLHandler extends Logging {
         assert(estimatorProto.getType == proto.MlOperator.OperatorType.ESTIMATOR)
 
         val dataset = MLUtils.parseRelationProto(fitCmd.getDataset, sessionHolder)
-        val estimator = MLUtils.getEstimator(estimatorProto, Some(fitCmd.getParams))
+        val estimator = MLUtils.getEstimator(sessionHolder, estimatorProto, Some(fitCmd.getParams))
         val model = estimator.fit(dataset).asInstanceOf[Model[_]]
         val id = mlCache.register(model)
         proto.MlCommandResult
@@ -176,7 +176,8 @@ private[connect] object MLHandler extends Logging {
           case proto.MlCommand.Write.TypeCase.OPERATOR =>
             val writer = mlCommand.getWrite
             if (writer.getOperator.getType == proto.MlOperator.OperatorType.ESTIMATOR) {
-              val estimator = MLUtils.getEstimator(writer.getOperator, Some(writer.getParams))
+              val estimator = MLUtils.getEstimator(sessionHolder, writer.getOperator,
+                Some(writer.getParams))
               estimator match {
                 case m: MLWritable => MLUtils.write(m, mlCommand.getWrite)
                 case other => throw MlUnsupportedException(s"Estimator $other is not writable")

--- a/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
+++ b/sql/connect/server/src/main/scala/org/apache/spark/sql/connect/ml/MLUtils.scala
@@ -55,7 +55,7 @@ private[ml] object MLUtils {
     mutable.HashMap.from(providers.map(est => est.getClass.getName -> est.getClass).toMap)
   }
 
-  private lazy val estimators = loadOperators(classOf[Estimator[_]])
+  private def estimators = loadOperators(classOf[Estimator[_]])
 
   private lazy val transformers = loadOperators(classOf[Transformer])
 

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/ml/MLBackendSuite.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.connect.ml
+
+import org.apache.spark.{SparkEnv, SparkFunSuite}
+import org.apache.spark.connect.proto
+import org.apache.spark.ml.{Estimator, Model}
+import org.apache.spark.ml.linalg.{Vectors, VectorUDT}
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.shared.HasMaxIter
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.UnsafeProjection
+import org.apache.spark.sql.catalyst.types.DataTypeUtils
+import org.apache.spark.sql.connect.SparkConnectTestUtils
+import org.apache.spark.sql.connect.config.Connect
+import org.apache.spark.sql.connect.planner.SparkConnectPlanTest
+import org.apache.spark.sql.types.{FloatType, Metadata, StructField, StructType}
+
+class MyLogisticRegressionModel(override val uid: String,
+                                val intercept: Float,
+                                val coefficients: Float)
+  extends Model[MyLogisticRegressionModel] with HasMaxIter {
+
+  override def copy(extra: ParamMap): MyLogisticRegressionModel =
+    defaultCopy(extra).asInstanceOf[MyLogisticRegressionModel]
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    dataset.toDF()
+  }
+
+  override def transformSchema(schema: StructType): StructType = schema
+}
+
+class MyLogisticRegression(override val uid: String) extends Estimator[MyLogisticRegressionModel]
+  with HasMaxIter {
+  setDefault(maxIter, 100)
+  def this() = this(Identifiable.randomUID("MyLogisticRegression"))
+
+  override def fit(dataset: Dataset[_]): MyLogisticRegressionModel = {
+    new MyLogisticRegressionModel(uid, 3.5f, 4.6f)
+  }
+
+  override def copy(extra: ParamMap): MyLogisticRegression = {
+    defaultCopy(extra).asInstanceOf[MyLogisticRegression]
+  }
+
+  override def transformSchema(schema: StructType): StructType = schema
+}
+
+class MLBackendSuite extends SparkFunSuite with SparkConnectPlanTest {
+
+  def createLocalRelationProto: proto.Relation = {
+    val udt = new VectorUDT()
+    val rows = Seq(
+      InternalRow(1.0f, udt.serialize(Vectors.dense(Array(1.0, 2.0)))),
+      InternalRow(1.0f, udt.serialize(Vectors.dense(Array(2.0, -1.0)))),
+      InternalRow(0.0f, udt.serialize(Vectors.dense(Array(-3.0, -2.0)))),
+      InternalRow(0.0f, udt.serialize(Vectors.dense(Array(-1.0, -2.0)))))
+
+    val schema = StructType(
+      Seq(
+        StructField("label", FloatType),
+        StructField("features", new VectorUDT(), false, Metadata.empty)))
+
+    val inputRows = rows.map { row =>
+      val proj = UnsafeProjection.create(schema)
+      proj(row).copy()
+    }
+    createLocalRelationProto(DataTypeUtils.toAttributes(schema), inputRows, "UTC", Some(schema))
+  }
+
+  def withSparkConf(pairs: (String, String)*)(f: => Unit): Unit = {
+    val conf = SparkEnv.get.conf
+    pairs.foreach { kv => conf.set(kv._1, kv._2) }
+    try f
+    finally {
+      pairs.foreach { kv => conf.remove(kv._1) }
+    }
+  }
+
+  test("MlBackendSuite") {
+    withSparkConf(
+      (Connect.CONNECT_EXTENSIONS_ML_OVERRIDES.key,
+        "org.apache.spark.ml.classification.LogisticRegression=" +
+          "org.apache.spark.sql.connect.ml.MyLogisticRegression")) {
+      val sessionHolder = SparkConnectTestUtils.createDummySessionHolder(spark)
+      val myEstClass = classOf[MyLogisticRegression]
+      try {
+        MLUtils.addEstimator(myEstClass.getName, myEstClass)
+
+        val fitCommand = proto.MlCommand
+          .newBuilder()
+          .setFit(
+            proto.MlCommand.Fit
+              .newBuilder()
+              .setDataset(createLocalRelationProto)
+              .setEstimator(
+                proto.MlOperator
+                  .newBuilder()
+                  .setName("org.apache.spark.ml.classification.LogisticRegression")
+                  .setUid("LogisticRegression")
+                  .setType(proto.MlOperator.OperatorType.ESTIMATOR))
+              .setParams(
+                proto.MlParams
+                  .newBuilder()
+                  .putParams(
+                    "maxIter",
+                    proto.Param
+                      .newBuilder()
+                      .setLiteral(proto.Expression.Literal
+                        .newBuilder()
+                        .setInteger(2))
+                      .build())))
+          .build()
+        val fitResult = MLHandler.handleMlCommand(sessionHolder, fitCommand)
+        val modelId = fitResult.getOperatorInfo.getObjRef.getId
+        assert(sessionHolder.mlCache.get(modelId).isInstanceOf[MyLogisticRegressionModel])
+        val model = sessionHolder.mlCache.get(modelId).asInstanceOf[MyLogisticRegressionModel]
+        assert(model.intercept == 3.5f)
+        assert(model.coefficients == 4.6f)
+      } finally {
+        MLUtils.removeEstimator(myEstClass.getName)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Users can specify the ML overrides by 

`spark.connect.extensions.ml.overrides="org.apache.spark.ml.classification.LogisticRegression=org.apache.spark.sql.connect.ml.MyLogisticRegression"`